### PR TITLE
Fix Lyrositor#8, fix Lyrositor#12

### DIFF
--- a/CCScriptWriter/CCScriptWriter.py
+++ b/CCScriptWriter/CCScriptWriter.py
@@ -191,9 +191,11 @@ COILSNAKE_POINTERS = ["Text Address", "Death Text Pointer",
                       "Delivery Success Text Pointer", "Pointer"]
 
 SPECIAL_POINTERS = [0x49ea4, 0x49ea8, 0x49eac, 0x49eb0, 0x49eb4, 0x49eb8,
-                    0x49ebc, 0x49ec0, 0xcffd5]
+                    0x49ebc, 0x49ec0]
 
 ASM_POINTERS = [0x49dbd, 0x49dc9, 0x4f252]
+
+MOVEMENT_POINTERS = [0x3d44b]
 
 HEADER = f"""/*
  * EarthBound Text Dump
@@ -280,6 +282,7 @@ def test_CoilSnakePointerStringToInt():
     except ValueError:
         pass
 
+
 ##################
 # CCScriptWriter #
 ##################
@@ -294,6 +297,7 @@ class CCScriptWriter:
         self.data = array.array("B")
         self.dialogue = {}
         self.dataFiles = {}
+        self.movementPointers = {}
         self.outputDirectory = outputDirectory
         self.pointers = []
         self.raw = raw
@@ -353,6 +357,11 @@ class CCScriptWriter:
                 address += " {}".format(FormatHex(self.data[i]))
                 i += 1
             self.pointers.append(FromSNES(address))
+        for p in MOVEMENT_POINTERS:
+            address = bytearray(self.data[p+2:p+4])
+            address.extend(self.data[p+0:p+2])
+            address_str = ' '.join([FormatHex(a) for a in address])
+            self.pointers.append(FromSNES(address_str))
 
         # Add new blocks as needed by the pointers.
         print("Checking pointers...")
@@ -406,6 +415,12 @@ class CCScriptWriter:
             m = self.dataFiles[address]
             h = hex(address)
             self.asmPointers[a] = ["{}.l_{}".format(m, h), t]
+        for p in MOVEMENT_POINTERS:
+            address = bytearray(self.data[p+2:p+4])
+            address.extend(self.data[p+0:p+2])
+            address_int = int.from_bytes(address, 'little')
+            module = self.dataFiles[address_int]
+            self.movementPointers[p] = "{{short [1] {0}.l_{1}}}{{short [0] {0}.l_{1}}}".format(module, hex(address_int))
 
     def loadCoilSnakeDialogue(self):
         "Load pointers from the CoilSnake project."
@@ -524,6 +539,8 @@ class CCScriptWriter:
                     m("\n_asmptr({}, {})".format(hex(k + 0xc00000), p[0]))
                 elif p[1] == 1:
                     m("\n_lasmptr({}, {})".format(hex(k + 0xc00000), p[0]))
+            for k, p in self.movementPointers.items():
+                m("\nROM[{}] = \"{}\"".format(hex(k + 0xc00000), p))
 
         # Optionally output to the CoilSnake project.
         if outputCoilSnake:

--- a/CCScriptWriter/CCScriptWriter.py
+++ b/CCScriptWriter/CCScriptWriter.py
@@ -358,6 +358,8 @@ class CCScriptWriter:
                 i += 1
             self.pointers.append(FromSNES(address))
         for p in MOVEMENT_POINTERS:
+            # The "queue text" ASM at C0A88D expects to see the address with the high word first,
+            # then the low word. FromSNES needs the bytes of the low word first.
             address = bytearray(self.data[p+2:p+4])
             address.extend(self.data[p+0:p+2])
             address_str = ' '.join([FormatHex(a) for a in address])


### PR DESCRIPTION
The removed pointer is part of the sequence data for a late subroutine in the Lost Underworld. I don't think anyone's reported any hacks as having wrong notes in the Lost Underworld theme, but... it definitely seems like it would've actively caused issues, replacing a vibrato command's parameters and a tie command. It is a relatively insignificant channel in the music, so maybe it went unnoticed in CoilSnake <= 4.1?

Two of the Mother 2 CCScriptWriter fork devs discovered and reported this issue in the PK Hack Discord server on 2026-07-22. It looks like Chaz also reported the issue about 9 years ago.

The rest of the commit adds a script label that only exists in the movement script and isn't automatically detected by the `eob` logic. Finally we have a programmatic solution instead of a workaround! The Runaway Five can say "all right... on to Threed!" without the player needing to run away from them. A quick search by vittorio and Catador turned up no other labels that suffer from fallthrough like this.